### PR TITLE
fix: make sure package cache updated

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
       ansible.builtin.yum:
         name: '*'
         state: latest
+        update_cache: true
       tags:
         - skip_ansible_lint
 
@@ -40,6 +41,7 @@
       ansible.builtin.apt:
         pkg: aptitude
         state: present
+        update_cache: true
 
     - name: Debian/Ubuntu | upgrade all packages (Debian)
       ansible.builtin.apt:


### PR DESCRIPTION
I have issue that apt couldn't find package aptitude. It turns out that I need to run `apt update` first. 
It is also good to make sure that we run `apt update` first before upgrading all of the packages.